### PR TITLE
Cleanup tweak

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -946,15 +946,10 @@ Basic erc setup
 #+end_src
 
 * Completion & searching 
-** company mode
-#+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
-  (use-package company-mode
-    :ensure t)
-#+end_src
 
 ** ivy 
 Includes a number of minimalist completion tools that make life a bit easier.
-#+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
+#+begin_src emacs-lisp 
 (use-package ivy
   :diminish
   :bind (("C-s" . swiper)
@@ -974,6 +969,17 @@ Includes a number of minimalist completion tools that make life a bit easier.
   (ivy-mode 1))
 #+end_src
 
+#+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
+  (use-package consult
+    :ensure t)
+#+end_src
+
+#+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
+  (use-package vertico
+    :ensure t
+    :bind (("C-s" . swiper)))
+#+end_src
+
 ** counsel
 ~M-x~ on steroids
 
@@ -984,7 +990,6 @@ Includes a number of minimalist completion tools that make life a bit easier.
          ("C-x C-f" . counsel-find-file)
          :map minibuffer-local-map
          ("C-r" . 'counsel-minibuffer-history)))
-         
 #+end_src
 
 ** ctags
@@ -1001,6 +1006,7 @@ Includes a number of minimalist completion tools that make life a bit easier.
    #+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
    (use-package yasnippet)
    #+end_src
+
 ** company
 #+begin_src emacs-lisp :tangle emacs/.emacs.d/init.el
 (use-package company

--- a/emacs/.emacs.d/init.el
+++ b/emacs/.emacs.d/init.el
@@ -636,26 +636,12 @@ GROUP BY id")))
         markdown-command
         "pandoc -f markdown -t html5 -s --self-contained --smart"))
 
-(use-package company-mode
+(use-package consult
   :ensure t)
 
-(use-package ivy
-  :diminish
-  :bind (("C-s" . swiper)
-         :map ivy-minibuffer-map
-         ("TAB" . ivy-alt-done)
-         ("C-l" . ivy-alt-done)
-         ("C-j" . ivy-next-line)
-         ("C-k" . ivy-previous-line)
-         :map ivy-switch-buffer-map
-         ("C-k" . ivy-previous-line)
-         ("C-l" . ivy-done)
-         ("C-d" . ivy-switch-buffer-kill)
-         :map ivy-reverse-i-search-map
-         ("C-k" . ivy-previous-line)
-         ("C-d" . ivy-reverse-i-search-kill))
-  :config
-  (ivy-mode 1))
+(use-package vertico
+  :ensure t
+  :bind (("C-s" . swiper)))
 
 (use-package counsel
   :bind (("M-x" . counsel-M-x)


### PR DESCRIPTION
Disable/remove ivy for now. Include the use of vertigo instead.