### PR TITLE
Patches to nvim dotfiles after updating to v0.11.0

### DIFF
--- a/nvim/.config/nvim/after/plugin/treesitter.rc.lua
+++ b/nvim/.config/nvim/after/plugin/treesitter.rc.lua
@@ -1,50 +1,55 @@
-require'nvim-treesitter.configs'.setup {
-    highlight = {
-        enable = true,
-        disable = {},
-        },
-    indent = {
-        enable = false,
-        disable = {},
-        },
-    ensure_installed = {
-        "tsx",
-        "yaml",
-        "json",
-        "html",
-        "javascript",
-        "typescript",
-        "css",
-        "python",
-        "go",
-        "c",
-        "lua"
-        },
+local has_tsconfigs, tsconfigs = pcall(require, 'nvim-treesitter.configs')
 
-    ignore_install = { "supercolider" },
+
+if has_tsconfigs then
+	tsconfigs.setup {
+	    highlight = {
+		enable = true,
+		disable = {},
+		},
+	    indent = {
+		enable = false,
+		disable = {},
+		},
+	    ensure_installed = {
+		"tsx",
+		"yaml",
+		"json",
+		"html",
+		"javascript",
+		"typescript",
+		"css",
+		"python",
+		"go",
+		"c",
+		"lua"
+		},
+
+	    ignore_install = { "supercolider" },
+	    playground = {
+	      enable = true,
+	      disable = {},
+	      updatetime = 25, -- Debounced time for highlighting nodes in the playground from source code
+	      persist_queries = false, -- Whether the query persists across vim sessions
+	      keybindings = {
+	        toggle_query_editor = 'o',
+	        toggle_hl_groups = 'i',
+	        toggle_injected_languages = 't',
+	        toggle_anonymous_nodes = 'a',
+	        toggle_language_display = 'I',
+	        focus_language = 'f',
+	        unfocus_language = 'F',
+	        update = 'R',
+	        goto_node = '<cr>',
+	        show_help = '?',
+	      },
+	    }
     }
+    end
 
-local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
-parser_config.tsx.filetype_to_parsername = { "javascript", "typescript.tsx" }
+local has_tsparsers, tsparsers = pcall(require, "nvim-treesitter.parsers")
 
--- Treesitter playground module
-require "nvim-treesitter.configs".setup {
-  playground = {
-    enable = true,
-    disable = {},
-    updatetime = 25, -- Debounced time for highlighting nodes in the playground from source code
-    persist_queries = false, -- Whether the query persists across vim sessions
-    keybindings = {
-      toggle_query_editor = 'o',
-      toggle_hl_groups = 'i',
-      toggle_injected_languages = 't',
-      toggle_anonymous_nodes = 'a',
-      toggle_language_display = 'I',
-      focus_language = 'f',
-      unfocus_language = 'F',
-      update = 'R',
-      goto_node = '<cr>',
-      show_help = '?',
-    },
-  }
-}
+if has_tsparsers then
+	local parser_config = tsparsers.get_parser_configs()
+	parser_config.tsx.filetype_to_parsername = { "javascript", "typescript.tsx" }
+end

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -47,7 +47,7 @@ if vim.o.loadplugins then
     vim.cmd('packadd! nightfox')
     vim.cmd('packadd! fzf-lua')
     vim.cmd('packadd! vim-slime')
-    --vim.cmd('packadd! conjure')
+    vim.cmd('packadd! conjure')
     --vim.cmd('packadd! go.nvim')
     --vim.cmd('packadd! guihua.lua')
     ---- optional for icon support

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -34,7 +34,6 @@ let g:slime_default_config = {"socket_name": "default", "target_pane": "{last}"}
 autocmd! bufwritepost .vimrc source %
 
 " Better copy & paste
-set pastetoggle=<F2>
 set clipboard=unnamed
 
 " Mouse and backspace


### PR DESCRIPTION
changes:

+ make treesitter-rc.lua a bit safer by adding checks for imports
+ remove redundant togglepate<f2> thingy from .vimrc