### PR TITLE
Clear out profiles for malloy and malone

### DIFF
--- a/admccartney/home-config/malloy.scm
+++ b/admccartney/home-config/malloy.scm
@@ -25,18 +25,11 @@
    "stow"
    "tree"
 
-   ;; wayland extras
-   "fuzzel"
-
    ;; passwords
    "password-store"
 
    ;; build tools
    "cmake"
-
-   ;; tty
-   "foot"
-   "zstd"
    
    ;; cli apps
    "ripgrep"
@@ -48,10 +41,6 @@
    "guile-colorized"
    "guile-readline"
    "nyacc"
-
-   ;; go
-   "go@1.23"
-   "xurls"
 
    ;; Emacs
    "emacs"
@@ -108,16 +97,12 @@
    "emacs-ement"
    "emacs-elfeed"
 
-   ;; vim + plugins
-   "vim-full"
-
    ;; mail
    "mu"
    "isync"
    "imapfilter"
    "mutt"
-   "neomutt"
-                                           )))
+   "neomutt")))
  
  (services
   (append
@@ -128,15 +113,10 @@
                                       "../../emacs"
                                       "../../systemd"
                                       "../../sway"
-                                      "../../vim"
-                                      "../../nvim"
                                       "../../tmux"
                                       "../../mail"
                                       "../../guile"
                                       "../../readline"
-                                      "../../mutt"))))
-
-          ;; Shell service
-         `(,@ad/shell-service)))))
+                                      "../../mutt"))))))))
 
 

--- a/admccartney/home-config/malone.scm
+++ b/admccartney/home-config/malone.scm
@@ -26,35 +26,8 @@
                                            ;; desktop
                                            "sway"
 
-                                           ;; Compatibility for older Xorg applications
-                                           "xorg-server-xwayland"
-
-                                           ;; Flatpak and XDG utilities
-                                           "flatpak"
-                                           "xdg-desktop-portal"
-                                           "xdg-desktop-portal-gtk"
-                                           "xdg-desktop-portal-wlr"
-                                           "xdg-utils" ;; For xdg-open, etc
-                                           "xdg-dbus-proxy"
-                                           "shared-mime-info"
-
-                                           ;; Appearance
-                                           "gnome-themes-extra"
-                                           "adwaita-icon-theme"
-
-                                           ;; Fonts
-                                           "font-iosevka"
-                                           "font-liberation"
-
                                            ;; Browsers
-                                           "vimb"
-
-                                           ;; Authentication
                                            "password-store"
-
-                                           ;; PDF reader
-                                           "zathura"
-                                           "zathura-pdf-mupdf"
 
                                            ;; General utilities
                                            "curl"
@@ -86,13 +59,6 @@
                                            "fzf"
                                            "tmux"
 
-                                           ;; vim
-                                           "vim"
-                                           "vim-guix-vim"
-                                           "vim-fugitive"
-                                           "vim-nerdtree"
-                                           "vim-slime"
-                                           
                                            ;; mail
                                            "mu"
                                            "tmux"

--- a/files/bash-rc
+++ b/files/bash-rc
@@ -15,6 +15,8 @@ if [ -d "$HOME/.local/bin" ] ; then
 fi
 
 
+#systemwide gopath
+export PATH=$PATH:/usr/local/go/bin
 export GOPATH="$HOME/go"
 # Go Setup (temporary?)
 if ! [[ $PATH =~ "$GOPATH/bin" ]]; then

--- a/mk-scripts/get-go
+++ b/mk-scripts/get-go
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+VERSION=1.24.4
+OS=linux
+ARCH=amd64
+
+GO_PKG_PREFIX=$HOME/.local/pkg
+
+curl -L -f -o "$GO_PKG_PREFIX"/go"$VERSION"."$OS"-"$ARCH".tar.gz https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
+pushd "$GO_PKG_PREFIX"
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
+popd
+

--- a/mk-scripts/ln-minimal
+++ b/mk-scripts/ln-minimal
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # TODO: make this do stuff
-# ln -s $HOME/dotfiles/vim/.vimrc $HOME/.vimrc
-# ln -s $HOME/dotfiles/vim/.vim $HOME/.vim
-# ln -s $HOME/dotfiles/nvim/.config/nvim $HOME/.config/nvim
+ln -sbv $HOME/dotfiles/vim/.vimrc $HOME/.vimrc
+ln -sbv $HOME/dotfiles/vim/.vim $HOME/.vim
+ln -sbv $HOME/dotfiles/nvim/.config/nvim $HOME/.config/nvim


### PR DESCRIPTION
This removes some stuff that was not getting used from guix (like go) and replaces it with more portable install method.