### PR TITLE
quickfix: add certs var for curl to bashrc

### DIFF
--- a/files/bash-rc
+++ b/files/bash-rc
@@ -6,6 +6,9 @@ export LC_ALL=C.UTF-8
 
 export EDITOR=vi
 
+# certs needed for curl
+export SSL_CERTS_DIR="/etc/ssl/certs"
+
 if [ -d "$HOME/bin" ] ; then
     export PATH="$PATH:$HOME/bin"
 fi


### PR DESCRIPTION
Curl needs to know about certs on the host. This location is derived from work on fedora 42